### PR TITLE
CO2 equivalent

### DIFF
--- a/src/views/comparator/co2Input/NumberInput.js
+++ b/src/views/comparator/co2Input/NumberInput.js
@@ -75,7 +75,7 @@ export default function NumberInput() {
           }}
         />
       </InputWrapper>
-      <Unit>kg/CO2</Unit>
+      <Unit>kg/CO2e</Unit>
     </Wrapper>
   )
 }


### PR DESCRIPTION
on parle de CO2 équivalent (e) car il y a aussi d'autres gaz pris en compte :
https://ecolab.gitbook.io/documentation-ecolab/lexique-environnemental-et-changement-climat#lequivalent-co2-ou-co2-equivalent-co-2-e