### PR TITLE
Jours chauffage x 2

### DIFF
--- a/public/data/equivalents.json
+++ b/public/data/equivalents.json
@@ -122,7 +122,7 @@
       "fr": "Jour[s] de chauffage (gaz)"
     },
     "emoji": "🏘️",
-    "total": 9.31506849,
+    "total": 18.63
     "default": false
   }
 ]


### PR DESCRIPTION
En France, la période de chauffage est généralement comprise entre le 15 octobre et le 15 avril de l'année suivante.
On chauffe donc en théorie "seulement" pendant ces 6 mois.